### PR TITLE
RMC-233 Request IR via EQ

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,8 +21,10 @@ class Config:
     QM_UNDELIVERED_TOPIC_NAME = "qm-undelivered-topic"
     QM_UNDELIVERED_PROJECT_ID = os.getenv("QM_UNDELIVERED_PROJECT_ID",
                                           "qm-undelivered-project")
-    FULFILMENT_CONFIRMED_TOPIC_NAME = "fulfilment-topic"
+    FULFILMENT_CONFIRMED_TOPIC_NAME = "fulfilment-confirmed-topic"
     FULFILMENT_CONFIRMED_PROJECT = os.getenv('FULFILMENT_CONFIRMED_PROJECT', 'fulfilment-confirmed-project')
+    EQ_FULFILMENT_TOPIC_NAME = "eq-fulfilment-topic"
+    EQ_FULFILMENT_PROJECT_NAME = os.getenv('FULFILMENT_CONFIRMED_PROJECT', 'eq-fulfilment-project')
     CASES_TO_FETCH = os.getenv("CASES_TO_FETCH", "50")
     UNADDRESSED_QIDS_TO_FETCH = os.getenv("UNADDRESSED_QIDS_TO_FETCH", "20")
     MESSAGE_RATE = os.getenv("MESSAGE_RATE", "1000")  # Messages per second


### PR DESCRIPTION
# Motivation and Context
Represent the inbound events in the load generator

# What has changed
* Add EQ sourced fulfilment events
* Fix fulfilment confirmed topic name

# How to test?
Run locally with the linked docker dev and pubsub adatper branches

# Links
https://trello.com/c/GBhnJs8F/144-rmc-233-request-ir-via-eq-13
https://github.com/ONSdigital/census-rm-pubsub-adapter/pull/17
https://github.com/ONSdigital/census-rm-docker-dev/pull/60